### PR TITLE
Make COMPASS.COM resume Compass if already in memory

### DIFF
--- a/src/COMFILE.ASM
+++ b/src/COMFILE.ASM
@@ -41,7 +41,7 @@ env_item_buffer: equ 3F00h
     db  "Based on Compass #1.2.09 by Compjoetania TNG",13,10,26
 	ds	#0100+headlncom-2-$,0	;reserve bytes
 	db	#09,#12	;IDbyte subnr (bit7=beta),mainnr
-skipid	LD	HL,queuebc+4
+skipid	LD	HL,queuebc+6
 	LD	DE,compass_ID
 	LD	B,#08
 J0109:	LD	A,(DE)
@@ -52,7 +52,13 @@ J0109:	LD	A,(DE)
 	DJNZ	J0109
 	LD	DE,txt_inmem
 	LD	C,#09
-	JP	bdos
+	call	bdos
+	ei
+	ld b,30	;Delay half a second for the message to be visible
+resuming:
+	halt
+	djnz resuming
+	jp queuebc+2
 J0119	ei
 	halt
 
@@ -1543,7 +1549,7 @@ skipmap1:
 
 ;*********************************************************data area
 compass_ID	db	"COMPASS",0
-txt_inmem	db	"Compass already in memory !",13,10,"$"
+txt_inmem	db	"Compass already in memory, resuming... $"
 txt_msx1	db	"Minimal MSX 2 required !",13,10,"$"
 startpalet	db	#00,#00,#00,#00,#77,#07,#04,#00
 	db	#17,#01,#27,#03,#51,#01,#27,#06

--- a/src/MAIN.ASM
+++ b/src/MAIN.ASM
@@ -161,14 +161,14 @@ newf349	dw	0	;under dos2 this remains 0
 oldf349	dw	0
 	ld	(#f349),hl
 alleslaten	XOR	A	;clear compassID
-	LD	(queuebc+4),A
+	LD	(queuebc+6),A
 	LD	A,(dosversion)	;delete envitem compass under dos2
 	CP	#02
 	JR	C,nietdos2
 	XOR	A	;replace space with period
 	LD	(compasscfg+7),A
 	LD	HL,compasscfg	;name
-	LD	DE,queuebc+4	;value =0
+	LD	DE,queuebc+6	;value =0
 	LD	C,#6C	;set envitem, now remove
 	CALL	bdos
 nietdos2	LD	A,#01
@@ -6064,6 +6064,7 @@ labelbuffer	ds	9,0
 buffer1024
 
 hook	jr	hookcontinue
+	jr hook_hoofd
 hook_slot	db	0
 hook_blok	db	0
 cmd_id	db	"COMPASS",0	;ID


### PR DESCRIPTION
Now if Compass is already in memory when COMPASS.COM is executed, Compass will be resumed as when pressing SHIFT+ESC or executing CMD COMPASS. Previously just a "Compass already in memory" error would be shown.