### PR TITLE
Fix: paths lost when switching source buffers in the disk menu

### DIFF
--- a/src/DEBUGGER.ASM
+++ b/src/DEBUGGER.ASM
@@ -62,14 +62,10 @@ WISBREAK	jp	wisbreak
 INSERTBREAK	jp	insertbreak
 MAININSTPROG	jp	mainconfig
 SETDEBPARS	jp	loadconfig
-;was SETGETPATH: jp filenames
-	ret
-	ret
-	ret
+SETGETPATH: jp filenames
 SETGETADRES	jp	setgetadres
 ABOUTPROG jp doabout
 REDEFCHARS jp doredefchars
-SETNAMEBUFFERS jp change_current_source_buffer
 PRINTDISKLINES jp print_disk_lines
 
 wisbreak	ld	hl,breakbuf
@@ -100,6 +96,47 @@ loadconfig:
 	ld	bc,maxvbouts+1
 	ldir
 	ret
+
+
+;Get or seet path and file name for a given source buffer
+;
+;Input:
+;A = 0 to update buffer data
+;    <>0 to retrieve buffer data
+;B = buffer number
+;C:0 = 0 for Ascii, 1 for Asm
+;HL = address of path name
+;DE = address of file name
+
+filenames:
+	push	de
+	push	hl
+	ld	de,64+11
+	bit 0,c
+	ld	hl,filbuf_asm-(64+11)
+	jr nz,_filenames1
+	ld	hl,filbuf_asc-(64+11)
+_filenames1:
+	add	hl,de
+	djnz	_filenames1
+	ld	bc,64
+	or	a
+	jr	z,_filenames2
+	pop	de
+	ldir
+	pop	de
+_filenames3:
+	ld	bc,11
+	ldir
+	ret
+_filenames2:
+	ex	de,hl
+	pop	hl
+	ldir
+	pop	hl
+	jr	_filenames3
+filbuf_asm:	ds	4*(64+11),0
+filbuf_asc:	ds	4*(64+11),0
 
 realfkeys	ds	10
 
@@ -5961,85 +5998,6 @@ vormen_sq	db	#10,#10,#10,#ff,#00,#00,#00,#00	;17
 	db	#10,#10,#10,#f0,#00,#00,#00,#00	;27
 	db	#00,#0f,#1f,#1f,#1f,#1f,#0f,#00	;28
 	db	#00,#c0,#e0,#e0,#e0,#e0,#c0,#00	;29
-
-
-; Adjust ASM and ASCII file names in the disk menu
-; when changing the current source buffer
-; (moved here due to exhaustion of space in main segment)
-;
-; Input: E = Old source buffer number
-;        D = New source buffer number
-;        IX = Address of name_asm
-
-change_current_source_buffer:
-	ld a,e
-	or a
-	ret z	;Nothing to do if no old buffer number
-	cp d
-	ret z	;Nothing to do if not actually changing the buffer number
-
-	push de
-
-	;First backup the current name_asm and name_asc
-	;into the appropriate entries in names_asm_for_buffers
-	;and names_asc_for_buffers for the old buffer.
-	
-	call get_buffer_name_asm_address
-	push hl
-	ex de,hl
-	push ix
-	pop hl
-	ld bc,11
-	ldir	;HL points now to name_asc
-	ex de,hl
-	pop hl
-	ld bc,4*11
-	add hl,bc	;Entry in asc buffer = entry in asm buffer + 11*4
-	ex de,hl
-	ld bc,11
-	ldir
-
-	;Now set the name from the asm and asc buffers into
-	;the appropriate entries in names_asm_for_buffers
-	;and names_asc_for_buffers for the new buffer.
-
-	pop af
-
-	call get_buffer_name_asm_address
-	push hl
-	push ix
-	pop de
-	ld bc,11
-	ldir	;DE points now to name_asc
-	pop hl
-	ld bc,4*11
-	add hl,bc	;Entry in asc buffer = entry in asm buffer + 11*4
-	ld bc,11
-	ldir
-	ret
-
-;Input:  A = Buffer num, 1-4
-;Output: HL = Address in names_asm_for_buffers
-get_buffer_name_asm_address:
-	ld hl,names_asm_for_buffers-11
-	ld b,a
-	ld de,11
-_get_buf_name_asm_address_loop:
-	add hl,de
-	djnz _get_buf_name_asm_address_loop
-	ret
-
-;ASM and ASCII file names for each source buffer
-names_asm_for_buffers:
-	db "NAME    ASM"
-	db "NAME    ASM"
-	db "NAME    ASM"
-	db "NAME    ASM"
-names_asc_for_buffers:
-	db "NAME    ASC"
-	db "NAME    ASC"
-	db "NAME    ASC"
-	db "NAME    ASC"
 
 
 ;Print the disk menu frame and fixed texts

--- a/src/MAIN.ASM
+++ b/src/MAIN.ASM
@@ -60,8 +60,7 @@ MAININSTPROG	equ	#4009	;in debugger segment
 SETDEBPARS	equ	#400c	;in debugger segment
 ABOUTPROG equ #4015 	;in debugger segment
 REDEFCHARS equ #4018 	;in debugger segment
-SETNAMEBUFFERS equ #401B	;in debugger segment
-PRINTDISKLINES equ #401E	;in debugger segment
+PRINTDISKLINES equ #401B	;in debugger segment
 
 ;--------------------------------------------
 	ORG	#0140
@@ -287,6 +286,27 @@ fill_NAMEASM:
 	LD	DE,pathname	;pathnamebuffer
 	LD	BC,64
 	LDIR
+
+	ld a,(Soort)
+	push af
+	ld a,1
+	ld (Soort),a
+	call init_asm_asc_filename_buffers
+	ld a,2
+	ld (Soort),a
+	call init_asm_asc_filename_buffers
+	pop af
+	ld (Soort),a
+	ret
+
+init_asm_asc_filename_buffers:
+	LD	B,4
+nxt_name_deb:
+	PUSH	BC
+	XOR	A	;load 4 filenames+path in debugger for ASM
+	CALL	parse_nam_deb
+	POP	BC
+	DJNZ	nxt_name_deb
 	ret
 
 chk_comline	LD	A,(#0080)	;is there anything else on the command line?
@@ -554,14 +574,6 @@ slotass	equ	tab_compass+4	;ok
 slotmonitor	equ	tab_compass+4	;ok
 slotdebugger	equ	tab_compass+6	;ok
 slotsubroutin	db	0,2
-
-change_current_buffer:
-	ld de,(Buffer)
-	ld d,a
-	ld (Buffer),a
-	ld ix,name_asm
-	ld bc,SETNAMEBUFFERS
-	jp call_in_debugger
 
 slotregister	PUSH	BC
 	PUSH	DE
@@ -1174,6 +1186,8 @@ set_file_type_no_sector:
 	ld (Soort),a
 	call printtype
 	call prtfilenaam
+	call jon1
+	call printpath
 	scf
 	ret
 
@@ -1231,7 +1245,7 @@ GODISKDRIVE:
 	ld	a,b
 	ld	(Diskasm),a
 	ld a,c
-	call change_current_buffer
+	ld (Buffer),a
 	xor	a
 	ld	(Formatdone),a
 	ld	(doinclude),a
@@ -1434,7 +1448,7 @@ _ctrl1234	call	WISKEYBUFFER
 	pop	bc
 	jp	c,diskhoofd
 	ld	a,b
-	call change_current_buffer
+	ld (Buffer),a
 	call	jon1
 	jp	diskhoofdprt
 _ctrl1234_1	push	hl
@@ -2529,14 +2543,35 @@ jon1:
 	LD	A,(Diskasm)
 	OR	A
 	JR	NZ,_jon12
+	LD	A,(Soort)
+	CP	3
+	JR	C,_jon11
 	LD	HL,pathname
 	LD	DE,pathnamebuf
 	LD	BC,64
 	LDIR
 	RET
-
+_jon11:
+	LD	A,(Buffer)
+	LD	B,A
+parse_nam_deb:
+	ld h,a
+	ld a,(Soort)
+	ld c,a
+	dec a
+	LD	DE,name_asm
+	jr z,parse_nam_deb_2
+	LD	DE,name_asc
+parse_nam_deb_2:
+	ld a,h
+	LD	HL,pathnamebuf
+	PUSH	HL
+	LD	HL,#400F
+	JP	GOTODEBUGGER
 _jon12:
-	ld b,a
+	PUSH	AF
+	CALL	_jon11
+	POP	BC
 	LD	HL,name_com1
 	LD	DE,11
 _jon13:
@@ -2548,11 +2583,19 @@ _jon13:
 	LDIR
 	RET
 jon2:
+	LD	A,(Soort)
+	CP	3
+	JR	C,_jon21
 	LD	HL,pathnamebuf
 	LD	DE,pathname
 	LD	BC,64
 	LDIR
 	RET
+_jon21:
+	LD	A,(Buffer)
+	LD	B,A
+	XOR	A
+	JR	parse_nam_deb
 
 ;--input pathname
 inputpath:


### PR DESCRIPTION
Compass originally saved path and file names entered for each source buffer in the disk menu, so that they would be restored after switching to a different source buffer, but only for Asm files.

When the same feature was implemented for Ascii files in https://github.com/Konamiman/Compass/pull/9, the old existing code for this feature was removed and a completely new implementation was put in place. However this new implementation was storing only the file names, not the paths.

This pull request restores the old code and extends it to properly work with both Asm and Ascii files, saving both the path and the file name forr both file types.