### PR TITLE
Fix: config file not loaded when Konpass is launched from different directory

### DIFF
--- a/src/COMFILE.ASM
+++ b/src/COMFILE.ASM
@@ -417,11 +417,6 @@ load_config_dos2:
 	LD	BC,#FF00+_GENV
 	CALL	bdos	;get env item PROGRAM
 
-	ld hl,8000h
-	ld de,8100h
-	ld bc,128
-	ldir
-
 	ld a,'.'
 	ld (fcb_cfg+1+7),a
 	ld de,8100h


### PR DESCRIPTION
When Konpass was launched from a different directory in DOS 2 (e.g. Konpass is in the `A:\KONPASS` directory, then `A:\>KONPASS\KONPASS.COM` is executed) the configuration file `KONPASSS.CFG` was not being loaded, thus Konpass started with default values for all the configuration. This pull request fixes that.

Closes #13.