### PR TITLE
Don't invalidate disk buffers when flushing them

### DIFF
--- a/src/MAIN.ASM
+++ b/src/MAIN.ASM
@@ -6304,7 +6304,7 @@ flush_disk_buffers:
 	ld (flushing_disk_buffers),a
 
 	ld bc,0000h+_FLUSH
-	ld d,0FFh
+	ld d,0
 	call bdos
 flush_disk_buffers_cont:
 	xor a


### PR DESCRIPTION
This is a workaround for [a bug in Nextor](https://github.com/Konamiman/Nextor/issues/146) that reverts all drives to their default mappings when the `_FLUSH` function call is executed with the "flush and invalidate" option. This bug wasn't present in Compass because it didn't have any call to `_FLUSH` (Konpass executes it when entering the disk menu).

Closes #16.